### PR TITLE
Adding methods for writing unsigned Int so it's possible to write a UInt64

### DIFF
--- a/Sources/BitWriter.swift
+++ b/Sources/BitWriter.swift
@@ -7,42 +7,42 @@ import Foundation
 
 /// A type that contains functions for writing `Data` bit-by-bit (and byte-by-byte).
 public protocol BitWriter {
-
+    
     /// Data which contains writer's output (the last byte in progress is not included).
     var data: Data { get }
-
+    
     /// True, if writer's BIT pointer is aligned with the BYTE border.
     var isAligned: Bool { get }
-
+    
     /// Creates an instance for writing bits (and bytes).
     init()
-
+    
     /// Writes `bit`, advancing by one BIT position.
     func write(bit: UInt8)
-
+    
     /// Writes `bits`, advancing by `bits.count` BIT positions.
     func write(bits: [UInt8])
-
+    
     /// Writes `number`, using and advancing by `bitsCount` BIT positions.
     func write(number: Int, bitsCount: Int)
-
+    
     /// Writes `byte`, advancing by one BYTE position.
     func append(byte: UInt8)
-
+    
     /**
      Aligns writer's BIT pointer to the BYTE border, i.e. moves BIT pointer to the first BIT of the next BYTE,
      filling all skipped BIT positions with zeros.
      */
     func align()
-
+    
 }
 
 extension BitWriter {
-
+    
     public func write(bits: [UInt8]) {
         for bit in bits {
             self.write(bit: bit)
         }
     }
-
+    
 }

--- a/Sources/BitWriter.swift
+++ b/Sources/BitWriter.swift
@@ -25,6 +25,10 @@ public protocol BitWriter {
 
     /// Writes `number`, using and advancing by `bitsCount` BIT positions.
     func write(number: Int, bitsCount: Int)
+    
+    /// because you cant convert a UInt64 into an Int without potential for overflowing it, we need an unsingned variant of `write`
+    /// Writes unsigned `number`, using and advancing by `bitsCount` BIT positions.
+    func write(unsignedNumber: UInt, bitsCount: Int)
 
     /// Writes `byte`, advancing by one BYTE position.
     func append(byte: UInt8)

--- a/Sources/BitWriter.swift
+++ b/Sources/BitWriter.swift
@@ -7,42 +7,42 @@ import Foundation
 
 /// A type that contains functions for writing `Data` bit-by-bit (and byte-by-byte).
 public protocol BitWriter {
-    
+
     /// Data which contains writer's output (the last byte in progress is not included).
     var data: Data { get }
-    
+
     /// True, if writer's BIT pointer is aligned with the BYTE border.
     var isAligned: Bool { get }
-    
+
     /// Creates an instance for writing bits (and bytes).
     init()
-    
+
     /// Writes `bit`, advancing by one BIT position.
     func write(bit: UInt8)
-    
+
     /// Writes `bits`, advancing by `bits.count` BIT positions.
     func write(bits: [UInt8])
-    
+
     /// Writes `number`, using and advancing by `bitsCount` BIT positions.
     func write(number: Int, bitsCount: Int)
-    
+
     /// Writes `byte`, advancing by one BYTE position.
     func append(byte: UInt8)
-    
+
     /**
      Aligns writer's BIT pointer to the BYTE border, i.e. moves BIT pointer to the first BIT of the next BYTE,
      filling all skipped BIT positions with zeros.
      */
     func align()
-    
+
 }
 
 extension BitWriter {
-    
+
     public func write(bits: [UInt8]) {
         for bit in bits {
             self.write(bit: bit)
         }
     }
-    
+
 }

--- a/Sources/BitWriter.swift
+++ b/Sources/BitWriter.swift
@@ -25,10 +25,6 @@ public protocol BitWriter {
 
     /// Writes `number`, using and advancing by `bitsCount` BIT positions.
     func write(number: Int, bitsCount: Int)
-    
-    /// because you cant convert a UInt64 into an Int without potential for overflowing it, we need an unsingned variant of `write`
-    /// Writes unsigned `number`, using and advancing by `bitsCount` BIT positions.
-    func write(unsignedNumber: UInt, bitsCount: Int)
 
     /// Writes `byte`, advancing by one BYTE position.
     func append(byte: UInt8)

--- a/Sources/LsbBitWriter.swift
+++ b/Sources/LsbBitWriter.swift
@@ -54,7 +54,22 @@ public final class LsbBitWriter: BitWriter {
             mask <<= 1
         }
     }
+    
+    /**
+     Writes `number`, using and advancing by `bitsCount` BIT positions.
 
+     - Note: If `bitsCount` is smaller than the actual amount of `number`'s bits than the `number` will be truncated to
+     fit into `bitsCount` amount of bits.
+     - Note: Bits of `number` are processed using the same bit-numbering scheme as of the writer (i.e. "LSB 0").
+     - Note: this method is specifically useful when needing to write a UInt64 which can overflow and crash if converting to an Int when using the regular `write` method
+     */
+    public func write(unsignedNumber: UInt, bitsCount: Int) {
+        var mask: UInt = 1
+        for _ in 0..<bitsCount {
+            self.write(bit: unsignedNumber & mask > 0 ? 1 : 0)
+            mask <<= 1
+        }
+    }
     /**
      Writes `byte`, advancing by one BYTE position.
 

--- a/Sources/LsbBitWriter.swift
+++ b/Sources/LsbBitWriter.swift
@@ -61,7 +61,7 @@ public final class LsbBitWriter: BitWriter {
      - Note: If `bitsCount` is smaller than the actual amount of `number`'s bits than the `number` will be truncated to
      fit into `bitsCount` amount of bits.
      - Note: Bits of `number` are processed using the same bit-numbering scheme as of the writer (i.e. "LSB 0").
-     - Note: this method is specifically useful when needing to write a UInt64 which can overflow and crash if converting to an Int when using the regular `write` method
+     - Note: This method is specifically useful when needing to write a UInt64 which can overflow and crash if converting to an Int when using the regular `write` method
      */
     public func write(unsignedNumber: UInt, bitsCount: Int) {
         var mask: UInt = 1
@@ -70,6 +70,7 @@ public final class LsbBitWriter: BitWriter {
             mask <<= 1
         }
     }
+    
     /**
      Writes `byte`, advancing by one BYTE position.
 

--- a/Sources/MsbBitWriter.swift
+++ b/Sources/MsbBitWriter.swift
@@ -54,6 +54,22 @@ public final class MsbBitWriter: BitWriter {
             mask >>= 1
         }
     }
+    
+    /**
+     Writes `number`, using and advancing by `bitsCount` BIT positions.
+
+     - Note: If `bitsCount` is smaller than the actual amount of `number`'s bits than the `number` will be truncated to
+     fit into `bitsCount` amount of bits.
+     - Note: Bits of `number` are processed using the same bit-numbering scheme as of the writer (i.e. "MSB 0").
+     - Note: this method is specifically useful when needing to write a UInt64 which can overflow and crash if converting to an Int when using the regular `write` method
+     */
+    public func write(unsignedNumber: UInt, bitsCount: Int) {
+        var mask: UInt = 1 << (UInt(bitsCount) - 1)
+        for _ in 0..<bitsCount {
+            self.write(bit: unsignedNumber & mask > 0 ? 1 : 0)
+            mask >>= 1
+        }
+    }
 
     /**
      Writes `byte`, advancing by one BYTE position.

--- a/Sources/MsbBitWriter.swift
+++ b/Sources/MsbBitWriter.swift
@@ -61,10 +61,10 @@ public final class MsbBitWriter: BitWriter {
      - Note: If `bitsCount` is smaller than the actual amount of `number`'s bits than the `number` will be truncated to
      fit into `bitsCount` amount of bits.
      - Note: Bits of `number` are processed using the same bit-numbering scheme as of the writer (i.e. "MSB 0").
-     - Note: this method is specifically useful when needing to write a UInt64 which can overflow and crash if converting to an Int when using the regular `write` method
+     - Note: This method is specifically useful when needing to write a UInt64 which can overflow and crash if converting to an Int when using the regular `write` method
      */
     public func write(unsignedNumber: UInt, bitsCount: Int) {
-        var mask: UInt = 1 << (UInt(bitsCount) - 1)
+        var mask: UInt = 1 << (UInt(truncatingIfNeeded: bitsCount) - 1)
         for _ in 0..<bitsCount {
             self.write(bit: unsignedNumber & mask > 0 ? 1 : 0)
             mask >>= 1

--- a/Tests/BitByteDataTests/LsbBitWriterTests.swift
+++ b/Tests/BitByteDataTests/LsbBitWriterTests.swift
@@ -78,5 +78,13 @@ class LsbBitWriterTests: XCTestCase {
         let bitReader = LsbBitReader(data: bitWriter.data)
         XCTAssertEqual(bitReader.int(fromBits: 14), 14582)
     }
+    
+    func testUInt64() {
+        let bitWriter = LsbBitWriter()
+        bitWriter.write(unsignedNumber: UInt(UInt64.max), bitsCount: UInt64.bitWidth)
+        
+        let byteReader = ByteReader.init(data: bitWriter.data)
+        XCTAssertEqual(byteReader.uint64(), UInt64.max)
+    }
 
 }

--- a/Tests/BitByteDataTests/MsbBitWriterTests.swift
+++ b/Tests/BitByteDataTests/MsbBitWriterTests.swift
@@ -81,5 +81,13 @@ class MsbBitWriterTests: XCTestCase {
         let bitReader = MsbBitReader(data: bitWriter.data)
         XCTAssertEqual(bitReader.int(fromBits: 14), 14582)
     }
+    
+    func testUInt64() {
+        let bitWriter = MsbBitWriter()
+        bitWriter.write(unsignedNumber: UInt(UInt64.max), bitsCount: UInt64.bitWidth)
+        
+        let byteReader = ByteReader.init(data: bitWriter.data)
+        XCTAssertEqual(byteReader.uint64(), UInt64.max)
+    }
 
 }


### PR DESCRIPTION
First off - thanks for writing and providing this - I've found it hugely helpful.  

I did run into a problem with the BitWriter's `write(number: bitsCount:)` method.  an Int is a flexible by platform type be that 32 or 64 bit, but it's always a signed integer.   If you have a UInt64, it is possible to have values well over the max value of a signed Int.  This results in an overflow crash as you try to write too large of a value into an Int.  If you were on a 32 bit system, the same problem would happen with trying to write a UInt32.  

So this PR is just a simple tweak to provide an additional `write` method where the number is a `UInt` rather than an `Int`.   ``write(unsignedNumber: bitsCount:)`